### PR TITLE
Update visualizer to new image name

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   visualizer:
-    image: manomarks/visualizer:latest
+    image: dockersamples/visualizer:latest
     hostname: visualizer
     ports:
     - 5001:8080


### PR DESCRIPTION
As per https://hub.docker.com/r/manomarks/visualizer/ the image has moved